### PR TITLE
stix-to-ecs update to v0.3.1

### DIFF
--- a/tools/stix-to-ecs/configuration.json
+++ b/tools/stix-to-ecs/configuration.json
@@ -1,7 +1,7 @@
 {
     "cloud_id": "",
-    "api_key": "",
     "url": "",
+    "api_key": "",
     "username": "",
     "password": "",
     "index": ""


### PR DESCRIPTION
- Fixed edge cases, added missing logic and refactored the code to reduce duplicated checks
- Updated Readme

Following v0.3 idea I fixed the code that we can now use the cloud-id or the cluster url  as well as the api-key or the logins (username, password) interchengeably and independently from how the cluster got deployed (local vs cloud).